### PR TITLE
Map view visual improvements

### DIFF
--- a/src/com/sfc/sf2/map/gui/MainEditor.form
+++ b/src/com/sfc/sf2/map/gui/MainEditor.form
@@ -159,12 +159,12 @@
                                   <Layout>
                                     <DimensionLayout dim="0">
                                       <Group type="103" groupAlignment="0" attributes="0">
-                                          <EmptySpace min="0" pref="858" max="32767" attributes="0"/>
+                                          <EmptySpace min="0" pref="799" max="32767" attributes="0"/>
                                       </Group>
                                     </DimensionLayout>
                                     <DimensionLayout dim="1">
                                       <Group type="103" groupAlignment="0" attributes="0">
-                                          <EmptySpace min="0" pref="715" max="32767" attributes="0"/>
+                                          <EmptySpace min="0" pref="714" max="32767" attributes="0"/>
                                       </Group>
                                     </DimensionLayout>
                                   </Layout>
@@ -233,6 +233,9 @@
                               </Layout>
                               <SubComponents>
                                 <Container class="javax.swing.JTabbedPane" name="jTabbedPane2">
+                                  <Events>
+                                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jTabbedPane2StateChanged"/>
+                                  </Events>
 
                                   <Layout class="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout"/>
                                   <SubComponents>
@@ -359,7 +362,7 @@
                                                                   <Component id="jSpinner1" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jLabel6" alignment="3" min="-2" max="-2" attributes="0"/>
                                                               </Group>
-                                                              <EmptySpace pref="7" max="32767" attributes="0"/>
+                                                              <EmptySpace max="32767" attributes="0"/>
                                                               <Component id="jPanel17" min="-2" max="-2" attributes="0"/>
                                                               <EmptySpace max="-2" attributes="0"/>
                                                               <Component id="jButton1" min="-2" pref="37" max="-2" attributes="0"/>
@@ -789,6 +792,9 @@
                                       </Layout>
                                       <SubComponents>
                                         <Container class="javax.swing.JTabbedPane" name="jTabbedPane3">
+                                          <Events>
+                                            <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jTabbedPane3StateChanged"/>
+                                          </Events>
 
                                           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout"/>
                                           <SubComponents>

--- a/src/com/sfc/sf2/map/gui/MainEditor.java
+++ b/src/com/sfc/sf2/map/gui/MainEditor.java
@@ -45,6 +45,8 @@ public class MainEditor extends javax.swing.JFrame {
     
     JCheckBox tabRelativeCheckbox;
     boolean tabRelativeCheckboxState;
+    JCheckBox actionRelativeCheckbox;
+    boolean actionRelativeCheckboxState;
     
     /**
      * Creates new form NewApplication
@@ -2886,15 +2888,15 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jRadioButton2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton2ActionPerformed
         /* Block graphics radio button */
-        mapPanel.setCurrentMode(MapLayoutLayout.MODE_BLOCK);
+        SetActionRelativeCheckbox(null, MapPanel.MODE_BLOCK);
     }//GEN-LAST:event_jRadioButton2ActionPerformed
 
     private void jRadioButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton1ActionPerformed
-        mapPanel.setCurrentMode(MapLayoutLayout.MODE_OBSTRUCTED);
+        SetActionRelativeCheckbox(jCheckBox1, MapPanel.MODE_OBSTRUCTED);
     }//GEN-LAST:event_jRadioButton1ActionPerformed
 
     private void jRadioButton3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton3ActionPerformed
-        mapPanel.setCurrentMode(MapLayoutLayout.MODE_STAIRS);
+        SetActionRelativeCheckbox(jCheckBox1, MapPanel.MODE_STAIRS);
     }//GEN-LAST:event_jRadioButton3ActionPerformed
 
     private void jTextField25ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField25ActionPerformed
@@ -3106,19 +3108,19 @@ public class MainEditor extends javax.swing.JFrame {
     }//GEN-LAST:event_jCheckBox8ActionPerformed
 
     private void jRadioButton4ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton4ActionPerformed
-        mapPanel.setCurrentMode(MapPanel.MODE_WARP);
+        SetActionRelativeCheckbox(jCheckBox7, MapPanel.MODE_WARP);
     }//GEN-LAST:event_jRadioButton4ActionPerformed
 
     private void jRadioButton5ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton5ActionPerformed
-        mapPanel.setCurrentMode(MapPanel.MODE_BARREL);
+        SetActionRelativeCheckbox(jCheckBox8, MapPanel.MODE_BARREL);
     }//GEN-LAST:event_jRadioButton5ActionPerformed
 
     private void jRadioButton6ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton6ActionPerformed
-        mapPanel.setCurrentMode(MapPanel.MODE_VASE);
+        SetActionRelativeCheckbox(jCheckBox8, MapPanel.MODE_VASE);
     }//GEN-LAST:event_jRadioButton6ActionPerformed
 
     private void jRadioButton7ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton7ActionPerformed
-        mapPanel.setCurrentMode(MapPanel.MODE_TABLE);
+        SetActionRelativeCheckbox(jCheckBox8, MapPanel.MODE_TABLE);
     }//GEN-LAST:event_jRadioButton7ActionPerformed
 
     private void jSpinner2StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner2StateChanged
@@ -3142,7 +3144,7 @@ public class MainEditor extends javax.swing.JFrame {
     }//GEN-LAST:event_jCheckBox9ActionPerformed
 
     private void jRadioButton8ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jRadioButton8ActionPerformed
-        mapPanel.setCurrentMode(MapPanel.MODE_TRIGGER);
+        SetActionRelativeCheckbox(jCheckBox9, MapPanel.MODE_TRIGGER);
     }//GEN-LAST:event_jRadioButton8ActionPerformed
 
     private void jTextField41ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField41ActionPerformed
@@ -3387,10 +3389,18 @@ public class MainEditor extends javax.swing.JFrame {
         SetTabRelativeCheckbox(null);
         JTabbedPane sourceTabbedPane = (JTabbedPane)evt.getSource();
         int index = sourceTabbedPane.getSelectedIndex();
+        mapPanel.setIsOnActionsTab(index == 0);
         switch (index) {
-            default:     //Layout & Anims
+            case 0:     //Actions & Anims
                 mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_ALL, false);
                 SetTabRelativeCheckbox(null);
+                
+                if (index == 0) {
+                    JCheckBox actionCheckbox = actionRelativeCheckbox;
+                    int mode = mapPanel.getCurrentMode();
+                    SetActionRelativeCheckbox(null, -1);
+                    SetActionRelativeCheckbox(actionCheckbox, mode);
+                }
                 break;
             case 1:     //Areas panel
                 mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_AREAS, true);
@@ -3447,15 +3457,46 @@ public class MainEditor extends javax.swing.JFrame {
             tabRelativeCheckbox = null;
         }
         else {
-            // Lock active checkbox
             if (tabRelativeCheckbox != null)
                 SetTabRelativeCheckbox(null);
+        
+            //If tabs change then disable the action tab affecting the checkboxes
+            if (!mapPanel.isDrawMode_Tabs(MapPanel.DRAW_MODE_ACTION_FLAGS)){
+                JCheckBox actionCheckbox = actionRelativeCheckbox;
+                int mode = mapPanel.getCurrentMode();
+                SetActionRelativeCheckbox(null, -1);
+                actionRelativeCheckbox = actionCheckbox;
+                mapPanel.setCurrentMode(mode);
+            }
             
+            // Lock active checkbox
             tabRelativeCheckbox = checkbox;
             tabRelativeCheckboxState = checkbox.isSelected();
             tabRelativeCheckbox.setSelected(true);
             tabRelativeCheckbox.setEnabled(false);
         }
+    }
+    
+    private void SetActionRelativeCheckbox(JCheckBox checkbox, int mode) {
+        if (mapPanel.getCurrentMode() == mode) return;
+        mapPanel.setCurrentMode(mode);
+        if (actionRelativeCheckbox != null) {
+            // Restore checkboxes
+            if (actionRelativeCheckbox != null) {
+                actionRelativeCheckbox.setSelected(actionRelativeCheckboxState);
+                actionRelativeCheckbox.setEnabled(true);
+            }
+            actionRelativeCheckbox = null;
+        }
+        if (checkbox != null) {
+            // Lock active checkbox
+            actionRelativeCheckbox = checkbox;
+            actionRelativeCheckboxState = checkbox.isSelected();
+            actionRelativeCheckbox.setSelected(true);
+            actionRelativeCheckbox.setEnabled(false);
+        }
+        jPanel2.revalidate();
+        jPanel2.repaint();
     }
     
     /**

--- a/src/com/sfc/sf2/map/gui/MainEditor.java
+++ b/src/com/sfc/sf2/map/gui/MainEditor.java
@@ -11,8 +11,6 @@ import com.sfc.sf2.map.block.layout.MapBlockLayout;
 import com.sfc.sf2.map.MapManager;
 import com.sfc.sf2.map.layout.layout.MapLayoutLayout;
 import java.awt.GridLayout;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.io.File;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
@@ -21,9 +19,11 @@ import java.nio.file.Paths;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
+import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
-import javax.swing.border.TitledBorder;
+import javax.swing.event.ChangeEvent;
 
 /**
  *
@@ -42,6 +42,9 @@ public class MainEditor extends javax.swing.JFrame {
     MapChestItemPropertiesTableModel chestItemTableModel;
     MapOtherItemPropertiesTableModel otherItemTableModel;
     MapAnimationFramePropertiesTableModel animFrameTableModel;
+    
+    JCheckBox tabRelativeCheckbox;
+    boolean tabRelativeCheckboxState;
     
     /**
      * Creates new form NewApplication
@@ -318,11 +321,11 @@ public class MainEditor extends javax.swing.JFrame {
         jPanel2.setLayout(jPanel2Layout);
         jPanel2Layout.setHorizontalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 858, Short.MAX_VALUE)
+            .addGap(0, 799, Short.MAX_VALUE)
         );
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 715, Short.MAX_VALUE)
+            .addGap(0, 714, Short.MAX_VALUE)
         );
 
         jScrollPane2.setViewportView(jPanel2);
@@ -355,6 +358,12 @@ public class MainEditor extends javax.swing.JFrame {
 
         jSplitPane4.setDividerLocation(250);
         jSplitPane4.setOneTouchExpandable(true);
+
+        jTabbedPane2.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                jTabbedPane2StateChanged(evt);
+            }
+        });
 
         jPanel4.setBorder(javax.swing.BorderFactory.createTitledBorder("Blockset"));
 
@@ -630,7 +639,7 @@ public class MainEditor extends javax.swing.JFrame {
                         .addGroup(jPanel14Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                             .addComponent(jSpinner1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(jLabel6))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 7, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addComponent(jPanel17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(jButton1, javax.swing.GroupLayout.PREFERRED_SIZE, 37, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -690,6 +699,12 @@ public class MainEditor extends javax.swing.JFrame {
         );
 
         jTabbedPane2.addTab("Areas", jPanel21);
+
+        jTabbedPane3.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                jTabbedPane3StateChanged(evt);
+            }
+        });
 
         jScrollPane7.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
         jScrollPane7.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
@@ -2651,15 +2666,15 @@ public class MainEditor extends javax.swing.JFrame {
         mapPanel.setMap(map);
         mapPanel.setMapLayout(map.getLayout());
         mapPanel.setBlockset(map.getBlocks());
-        mapPanel.setDrawExplorationFlags(jCheckBox1.isSelected());
-        mapPanel.setDrawGrid(jCheckBox2.isSelected());
-        mapPanel.setDrawAreas(jCheckBox3.isSelected());
-        mapPanel.setDrawFlagCopies(jCheckBox4.isSelected());
-        mapPanel.setDrawStepCopies(jCheckBox5.isSelected());
-        mapPanel.setDrawLayer2Copies(jCheckBox6.isSelected());
-        mapPanel.setDrawWarps(jCheckBox7.isSelected());
-        mapPanel.setDrawItems(jCheckBox8.isSelected());
-        mapPanel.setDrawTriggers(jCheckBox9.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_EXPLORATION_FLAGS, jCheckBox1.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_GRID, jCheckBox2.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_AREAS, jCheckBox3.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_FLAG_COPIES, jCheckBox4.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_STEP_COPIES, jCheckBox5.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_LAYER2_COPIES, jCheckBox6.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_WARPS, jCheckBox7.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_ITEMS, jCheckBox8.isSelected());
+        mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_TRIGGERS, jCheckBox9.isSelected());
         mapPanel.setCurrentDisplaySize(jComboBox1.getSelectedIndex()+1);
         jPanel2.add(mapPanel);
         jPanel2.setSize(mapPanel.getWidth(), mapPanel.getHeight());
@@ -2795,7 +2810,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox1ActionPerformed
         if(mapPanel!=null){
-            mapPanel.setDrawExplorationFlags(jCheckBox1.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_EXPLORATION_FLAGS, jCheckBox1.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -2863,7 +2878,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox2ActionPerformed
         if(mapPanel!=null){
-            mapPanel.setDrawGrid(jCheckBox2.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_GRID, jCheckBox2.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3044,7 +3059,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox3ActionPerformed
         if(mapPanel!=null){
-            mapPanel.setDrawAreas(jCheckBox3.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_AREAS, jCheckBox3.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3052,7 +3067,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox4ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox4ActionPerformed
         if(mapPanel!=null){
-            mapPanel.setDrawFlagCopies(jCheckBox4.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_FLAG_COPIES, jCheckBox4.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3060,7 +3075,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox5ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox5ActionPerformed
         if(mapPanel!=null){
-            mapPanel.setDrawStepCopies(jCheckBox5.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_STEP_COPIES, jCheckBox5.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3068,7 +3083,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox6ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox6ActionPerformed
         if(mapPanel!=null){
-            mapPanel.setDrawLayer2Copies(jCheckBox6.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_LAYER2_COPIES, jCheckBox6.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3076,7 +3091,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox7ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox7ActionPerformed
          if(mapPanel!=null){
-            mapPanel.setDrawWarps(jCheckBox7.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_WARPS, jCheckBox7.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3084,7 +3099,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox8ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox8ActionPerformed
          if(mapPanel!=null){
-            mapPanel.setDrawItems(jCheckBox8.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_ITEMS, jCheckBox8.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3120,7 +3135,7 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jCheckBox9ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox9ActionPerformed
          if(mapPanel!=null){
-            mapPanel.setDrawTriggers(jCheckBox9.isSelected());
+            mapPanel.setDrawMode_Toggles(MapPanel.DRAW_MODE_TRIGGERS, jCheckBox9.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();
         }
@@ -3367,6 +3382,82 @@ public class MainEditor extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_jButton56ActionPerformed
 
+    private void jTabbedPane2StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jTabbedPane2StateChanged
+        if (mapPanel == null) return;
+        SetTabRelativeCheckbox(null);
+        JTabbedPane sourceTabbedPane = (JTabbedPane)evt.getSource();
+        int index = sourceTabbedPane.getSelectedIndex();
+        switch (index) {
+            default:     //Layout & Anims
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_ALL, false);
+                SetTabRelativeCheckbox(null);
+                break;
+            case 1:     //Areas panel
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_AREAS, true);
+                SetTabRelativeCheckbox(jCheckBox3);
+                break;
+            case 2:     //Block Copies panels
+                jTabbedPane3StateChanged(new ChangeEvent(jTabbedPane3));
+                break;
+            case 3:     //Warps panel
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_WARPS, true);
+                SetTabRelativeCheckbox(jCheckBox7);
+                break;
+            case 4:     //Items panel
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_ITEMS, true);
+                SetTabRelativeCheckbox(jCheckBox8);
+                break;
+        }
+        
+        jPanel2.revalidate();
+        jPanel2.repaint();
+    }//GEN-LAST:event_jTabbedPane2StateChanged
+
+    private void jTabbedPane3StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jTabbedPane3StateChanged
+        if (mapPanel == null) return;        
+        JTabbedPane sourceTabbedPane = (JTabbedPane)evt.getSource();
+        int index = sourceTabbedPane.getSelectedIndex();
+        switch (index) {
+            default:     //Layout and Anims & Block Copies panels
+                return;
+            case 0:     //Flag copies
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_FLAG_COPIES, true);
+                SetTabRelativeCheckbox(jCheckBox4);
+                break;
+            case 1:     //Step copies
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_STEP_COPIES, true);
+                SetTabRelativeCheckbox(jCheckBox5);
+                break;
+            case 2:     //Roof copies
+                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_LAYER2_COPIES, true);
+                SetTabRelativeCheckbox(jCheckBox6);
+                break;
+        }
+        jPanel2.revalidate();
+        jPanel2.repaint();
+    }//GEN-LAST:event_jTabbedPane3StateChanged
+
+    private void SetTabRelativeCheckbox(JCheckBox checkbox) {
+        if (checkbox == null) {
+            // Restore checkboxes
+            if (tabRelativeCheckbox != null) {
+                tabRelativeCheckbox.setSelected(tabRelativeCheckboxState);
+                tabRelativeCheckbox.setEnabled(true);
+            }
+            tabRelativeCheckbox = null;
+        }
+        else {
+            // Lock active checkbox
+            if (tabRelativeCheckbox != null)
+                SetTabRelativeCheckbox(null);
+            
+            tabRelativeCheckbox = checkbox;
+            tabRelativeCheckboxState = checkbox.isSelected();
+            tabRelativeCheckbox.setSelected(true);
+            tabRelativeCheckbox.setEnabled(false);
+        }
+    }
+    
     /**
      * @param args the command line arguments
      */

--- a/src/com/sfc/sf2/map/gui/MainEditor.java
+++ b/src/com/sfc/sf2/map/gui/MainEditor.java
@@ -3386,14 +3386,13 @@ public class MainEditor extends javax.swing.JFrame {
 
     private void jTabbedPane2StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jTabbedPane2StateChanged
         if (mapPanel == null) return;
-        SetTabRelativeCheckbox(null);
+        SetTabRelativeCheckbox(null, MapPanel.DRAW_MODE_NONE);
         JTabbedPane sourceTabbedPane = (JTabbedPane)evt.getSource();
         int index = sourceTabbedPane.getSelectedIndex();
         mapPanel.setIsOnActionsTab(index == 0);
         switch (index) {
             case 0:     //Actions & Anims
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_ALL, false);
-                SetTabRelativeCheckbox(null);
+                SetTabRelativeCheckbox(null, 0);
                 
                 if (index == 0) {
                     JCheckBox actionCheckbox = actionRelativeCheckbox;
@@ -3403,19 +3402,16 @@ public class MainEditor extends javax.swing.JFrame {
                 }
                 break;
             case 1:     //Areas panel
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_AREAS, true);
-                SetTabRelativeCheckbox(jCheckBox3);
+                SetTabRelativeCheckbox(jCheckBox3, MapPanel.DRAW_MODE_AREAS);
                 break;
             case 2:     //Block Copies panels
                 jTabbedPane3StateChanged(new ChangeEvent(jTabbedPane3));
                 break;
             case 3:     //Warps panel
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_WARPS, true);
-                SetTabRelativeCheckbox(jCheckBox7);
+                SetTabRelativeCheckbox(jCheckBox7, MapPanel.DRAW_MODE_WARPS);
                 break;
             case 4:     //Items panel
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_ITEMS, true);
-                SetTabRelativeCheckbox(jCheckBox8);
+                SetTabRelativeCheckbox(jCheckBox8, MapPanel.DRAW_MODE_ITEMS);
                 break;
         }
         
@@ -3424,30 +3420,28 @@ public class MainEditor extends javax.swing.JFrame {
     }//GEN-LAST:event_jTabbedPane2StateChanged
 
     private void jTabbedPane3StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jTabbedPane3StateChanged
-        if (mapPanel == null) return;        
+        if (mapPanel == null) return;
+        SetTabRelativeCheckbox(null, MapPanel.DRAW_MODE_NONE);
         JTabbedPane sourceTabbedPane = (JTabbedPane)evt.getSource();
         int index = sourceTabbedPane.getSelectedIndex();
         switch (index) {
             default:     //Layout and Anims & Block Copies panels
                 return;
             case 0:     //Flag copies
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_FLAG_COPIES, true);
-                SetTabRelativeCheckbox(jCheckBox4);
+                SetTabRelativeCheckbox(jCheckBox4, MapPanel.DRAW_MODE_FLAG_COPIES);
                 break;
             case 1:     //Step copies
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_STEP_COPIES, true);
-                SetTabRelativeCheckbox(jCheckBox5);
+                SetTabRelativeCheckbox(jCheckBox5, MapPanel.DRAW_MODE_STEP_COPIES);
                 break;
             case 2:     //Roof copies
-                mapPanel.setDrawMode_Tabs(MapPanel.DRAW_MODE_LAYER2_COPIES, true);
-                SetTabRelativeCheckbox(jCheckBox6);
+                SetTabRelativeCheckbox(jCheckBox6, MapPanel.DRAW_MODE_LAYER2_COPIES);
                 break;
         }
         jPanel2.revalidate();
         jPanel2.repaint();
     }//GEN-LAST:event_jTabbedPane3StateChanged
 
-    private void SetTabRelativeCheckbox(JCheckBox checkbox) {
+    private void SetTabRelativeCheckbox(JCheckBox checkbox, int mode) {
         if (checkbox == null) {
             // Restore checkboxes
             if (tabRelativeCheckbox != null) {
@@ -3458,18 +3452,19 @@ public class MainEditor extends javax.swing.JFrame {
         }
         else {
             if (tabRelativeCheckbox != null)
-                SetTabRelativeCheckbox(null);
+                SetTabRelativeCheckbox(null, 0);
         
             //If tabs change then disable the action tab affecting the checkboxes
             if (!mapPanel.isDrawMode_Tabs(MapPanel.DRAW_MODE_ACTION_FLAGS)){
                 JCheckBox actionCheckbox = actionRelativeCheckbox;
-                int mode = mapPanel.getCurrentMode();
+                int actionMode = mapPanel.getCurrentMode();
                 SetActionRelativeCheckbox(null, -1);
                 actionRelativeCheckbox = actionCheckbox;
-                mapPanel.setCurrentMode(mode);
+                mapPanel.setCurrentMode(actionMode);
             }
             
             // Lock active checkbox
+            mapPanel.setDrawMode_Tabs(mode);
             tabRelativeCheckbox = checkbox;
             tabRelativeCheckboxState = checkbox.isSelected();
             tabRelativeCheckbox.setSelected(true);

--- a/src/com/sfc/sf2/map/gui/MapPanel.java
+++ b/src/com/sfc/sf2/map/gui/MapPanel.java
@@ -132,7 +132,7 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);   
         g.drawImage(buildImage(), 0, 0, this);
-        g.drawImage(buildPreviewImage(), lastMapX*24, lastMapY*24, this);
+        g.drawImage(buildPreviewImage(), lastMapX*24*currentDisplaySize, lastMapY*24*currentDisplaySize, this);
     }
     
     public BufferedImage buildImage(){
@@ -276,6 +276,7 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
                 graphics.drawRect(0,0, 24, 24);
             }
             graphics.dispose();
+            previewImage = resize(previewImage);
         }
         
         return previewImage;

--- a/src/com/sfc/sf2/map/gui/MapPanel.java
+++ b/src/com/sfc/sf2/map/gui/MapPanel.java
@@ -1052,6 +1052,7 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
             block.setFlags(newFlags);
             block.setExplorationFlagImage(null);
             actions.add(action);
+            mapExplorationFlagsImage = null;
             redraw = true;
         }
     }

--- a/src/com/sfc/sf2/map/gui/MapPanel.java
+++ b/src/com/sfc/sf2/map/gui/MapPanel.java
@@ -424,10 +424,17 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
         if(obstructedImage==null){
             obstructedImage = new BufferedImage(3*8, 3*8, BufferedImage.TYPE_INT_ARGB);
             Graphics2D g2 = (Graphics2D) obstructedImage.getGraphics();  
-            g2.setColor(Color.RED);
+            g2.setColor(Color.BLACK);
+            g2.setStroke(new BasicStroke(3));
             Line2D line1 = new Line2D.Double(6, 6, 18, 18);
             g2.draw(line1);
             Line2D line2 = new Line2D.Double(6, 18, 18, 6);
+            g2.draw(line2);  
+            g2.setColor(Color.RED);
+            g2.setStroke(new BasicStroke(2));
+            line1 = new Line2D.Double(6, 6, 18, 18);
+            g2.draw(line1);
+            line2 = new Line2D.Double(6, 18, 18, 6);
             g2.draw(line2);
         }
         return obstructedImage;

--- a/src/com/sfc/sf2/map/gui/MapPanel.java
+++ b/src/com/sfc/sf2/map/gui/MapPanel.java
@@ -69,10 +69,11 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     int lastMapY = 0;
     
     BlockSlotPanel leftSlot = null;
+    private boolean isOnActionsTab = true;
     
     private int currentMode = 0;
     private int togglesDrawMode = 0;
-    private int seletectTabDrawMode = 0;
+    private int selectedTabsDrawMode = 0;
     
     private MapBlock selectedBlock0;
     MapBlock[][] copiedBlocks;
@@ -590,6 +591,8 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     }
     @Override
     public void mousePressed(MouseEvent e) {
+        if (!isOnActionsTab)
+            return;
         int x = e.getX() / (currentDisplaySize * 3*8);
         int y = e.getY() / (currentDisplaySize * 3*8);
         switch (currentMode) {
@@ -788,6 +791,8 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     }
     @Override
     public void mouseReleased(MouseEvent e) {
+        if (!isOnActionsTab)
+            return;
         int x = e.getX() / (currentDisplaySize * 3*8);
         int y = e.getY() / (currentDisplaySize * 3*8);
         switch (e.getButton()) {
@@ -838,11 +843,10 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
                         leftSlot.setBlockImage(img);
                         leftSlot.revalidate();
                         leftSlot.repaint(); 
-
                     }
                 }
-
                 break;
+                
             default:
                 break;
         }         
@@ -853,8 +857,7 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     }
 
     @Override
-    public void mouseMoved(MouseEvent e) {
-        
+    public void mouseMoved(MouseEvent e) {        
         int x = e.getX() / (currentDisplaySize * 3*8);
         int y = e.getY() / (currentDisplaySize * 3*8);
         
@@ -1028,6 +1031,7 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
 
     public void setCurrentMode(int currentMode) {
         this.currentMode = currentMode;
+        this.redraw=true;
     }
 
     public BlockSlotPanel getLeftSlot() {
@@ -1085,7 +1089,7 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     }
     
     private boolean shouldDraw(int drawFlag) {
-        return isDrawMode_Toggles(drawFlag) || isDrawMode_Tabs(drawFlag);
+        return isDrawMode_Toggles(drawFlag) || isDrawMode_Tabs(drawFlag) || isDrawMode_Actions(drawFlag);
     }
 
     public boolean isDrawMode_Toggles(int drawFlag) {
@@ -1093,7 +1097,9 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     }
 
     public void setDrawMode_Toggles(int drawFlag, boolean on) {
-        if (on)
+        if (drawFlag == DRAW_MODE_ALL)
+            togglesDrawMode = on ? drawFlag : 0;    
+        else if (on)
             togglesDrawMode = (togglesDrawMode | drawFlag);
         else
             togglesDrawMode = (togglesDrawMode & ~drawFlag);
@@ -1101,16 +1107,47 @@ public class MapPanel extends JPanel implements MouseListener, MouseMotionListen
     }
 
     public boolean isDrawMode_Tabs(int drawFlag) {
-        return (seletectTabDrawMode & drawFlag) > 0;
+        return (selectedTabsDrawMode & drawFlag) > 0;
     }
 
     public void setDrawMode_Tabs(int drawFlag, boolean on) {
-        seletectTabDrawMode = 0;
-        if (on)
-            seletectTabDrawMode = (seletectTabDrawMode | drawFlag);
+        if (drawFlag == DRAW_MODE_ALL)
+            selectedTabsDrawMode = on ? drawFlag : 0;        
+        else if (on)
+            selectedTabsDrawMode = (selectedTabsDrawMode | drawFlag);
         else
-            seletectTabDrawMode = (seletectTabDrawMode | ~drawFlag);
+            selectedTabsDrawMode = (selectedTabsDrawMode | ~drawFlag);
         this.redraw=true;
+    }
+
+    public boolean isDrawMode_Actions(int drawFlag) {
+        if (!isOnActionsTab)
+            return false;
+        
+        switch (currentMode)
+        {
+            case MODE_OBSTRUCTED:
+            case MODE_STAIRS:
+                return (DRAW_MODE_EXPLORATION_FLAGS & drawFlag) > 0;
+            case MODE_BARREL:
+            case MODE_VASE:
+            case MODE_TABLE:
+                return (DRAW_MODE_ITEMS & drawFlag) > 0;
+            case MODE_WARP:
+                return (DRAW_MODE_WARPS & drawFlag) > 0;
+            case MODE_TRIGGER:
+                return (DRAW_MODE_TRIGGERS & drawFlag) > 0;
+            default:
+                return false;
+        }
+    }
+    
+    public boolean getIsOnActionsTab() {        
+        return isOnActionsTab;
+    }
+    
+    public void setIsOnActionsTab(boolean isOnActionsTab) {
+        this.isOnActionsTab = isOnActionsTab;
     }
 
     public void setTriggersImage(BufferedImage triggersImage) {

--- a/src/com/sfc/sf2/map/io/GifManager.java
+++ b/src/com/sfc/sf2/map/io/GifManager.java
@@ -56,7 +56,7 @@ public class GifManager {
     
     public static void writeGifMapLayoutFile(MapPanel mapPanel, String filepath){
         try {
-            BufferedImage image = mapPanel.buildImage(mapPanel.getMap(),mapPanel.getTilesPerRow(),true);
+            BufferedImage image = mapPanel.buildMapImage(mapPanel.getMap(),mapPanel.getTilesPerRow(),true);
             File outputfile = new File(filepath);
             ImageIO.write(image, "gif", outputfile);
             System.out.println("GIF file exported : " + outputfile.getAbsolutePath());

--- a/src/com/sfc/sf2/map/io/PngManager.java
+++ b/src/com/sfc/sf2/map/io/PngManager.java
@@ -49,7 +49,7 @@ public class PngManager {
     
     public static void writePngMapFile(MapPanel mapPanel, String filepath){
         try {
-            BufferedImage image = mapPanel.buildImage(mapPanel.getMap(),mapPanel.getTilesPerRow(),true);
+            BufferedImage image = mapPanel.buildMapImage(mapPanel.getMap(),mapPanel.getTilesPerRow(),true);
             File outputfile = new File(filepath);
             ImageIO.write(image, "png", outputfile);
             System.out.println("PNG file exported : " + outputfile.getAbsolutePath());
@@ -97,7 +97,7 @@ public class PngManager {
     
     public static void writePngMapLayoutFile(MapPanel mapPanel, String filepath){
         try {
-            BufferedImage image = mapPanel.buildImage(mapPanel.getMap(),mapPanel.getTilesPerRow(),true);
+            BufferedImage image = mapPanel.buildMapImage(mapPanel.getMap(),mapPanel.getTilesPerRow(),true);
             File outputfile = new File(filepath);
             ImageIO.write(image, "png", outputfile);
             System.out.println("PNG file exported : " + outputfile.getAbsolutePath());


### PR DESCRIPTION
1. Obstruction flags are thicker and easier to see (partly because red-on-green is not colorblind friendly)
2. Changing tabs will 1) disable the actions (editing the map) and 2) automatically toggle on the relevant views
     - i.e. if I am editing warps then I probably want to see the warps
4. Changing the action buttons (radio buttons) will automatically toggle on the relevant views
     - i.e. if I am placing barrel flags then I probably want to see the current barrel flags
6. Overlay of preview image of current action (i.e. shows what you are going to place)
7. Warps with a range (i.e. trigger value set to 0xFF) will render as a single, long, rect, instead of individual rects

NOTES:
- Draw modes changed to bit flags, to support multiple being active at once (for auto-showing for tabs/actions)